### PR TITLE
feat: adoption roadmap phase 2 — first-run & popup ux

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Current empty state offers four competing CTAs and a blank slate.
 - [x] Step 2: Add a common-header preset picker to the quick rule creator
       (Authorization, X-Api-Key, X-Forwarded-For, Cache-Control, …) so the
       first rule takes seconds, not minutes.
-- [ ] Step 3: Make the rule name optional in the quick rule creator
+- [x] Step 3: Make the rule name optional in the quick rule creator
       (auto-generated from header + domain), cutting required fields from
       three to two. (An active-rule-count toolbar badge was originally
       planned here, but the codebase already ships one.)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@ Current empty state offers four competing CTAs and a blank slate.
       ("Create rule", pre-filled with the current tab's domain), with
       templates/advanced editor demoted to text links. Also localizes the
       previously hardcoded popup button strings.
-- [ ] Step 2: Add a common-header preset picker to the quick rule creator
+- [x] Step 2: Add a common-header preset picker to the quick rule creator
       (Authorization, X-Api-Key, X-Forwarded-For, Cache-Control, …) so the
       first rule takes seconds, not minutes.
 - [ ] Step 3: Make the rule name optional in the quick rule creator

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,13 +50,17 @@ to be. Trust is the #1 conversion factor for this category.
 Most users decide within a minute whether an extension stays installed.
 Current empty state offers four competing CTAs and a blank slate.
 
-- [ ] Step 1: Focus the popup empty state on a single primary action
-      ("Create your first rule", pre-filled with the current tab's domain).
+- [x] Step 1: Focus the popup empty state on a single primary action
+      ("Create rule", pre-filled with the current tab's domain), with
+      templates/advanced editor demoted to text links. Also localizes the
+      previously hardcoded popup button strings.
 - [ ] Step 2: Add a common-header preset picker to the quick rule creator
       (Authorization, X-Api-Key, X-Forwarded-For, Cache-Control, …) so the
       first rule takes seconds, not minutes.
-- [ ] Step 3: Show an active-rule-count badge on the toolbar icon so users
-      can see the extension working without opening anything.
+- [ ] Step 3: Make the rule name optional in the quick rule creator
+      (auto-generated from header + domain), cutting required fields from
+      three to two. (An active-rule-count toolbar badge was originally
+      planned here, but the codebase already ships one.)
 - [ ] Step 4: Update roadmap progress. (`docs`)
 
 ## Phase 3 — Migration magnet

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Current empty state offers four competing CTAs and a blank slate.
       (auto-generated from header + domain), cutting required fields from
       three to two. (An active-rule-count toolbar badge was originally
       planned here, but the codebase already ships one.)
-- [ ] Step 4: Update roadmap progress. (`docs`)
+- [x] Step 4: Update roadmap progress. (`docs`)
 
 ## Phase 3 — Migration magnet
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -475,6 +475,10 @@
   "common_rule_name": {
     "message": "Rule Name"
   },
+  "common_optional": {
+    "message": "optional",
+    "description": "Suffix marking a form field as optional"
+  },
   "quick_rule_placeholder_name": {
     "message": "Headers for"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -604,6 +604,22 @@
   "popup_footer_developers": {
     "message": "for developers by developers."
   },
+  "popup_onboarding_title": {
+    "message": "Set your first header",
+    "description": "Title shown in popup when no rules exist yet"
+  },
+  "popup_onboarding_description": {
+    "message": "Inject a custom header for this site in seconds — no account, unlimited rules.",
+    "description": "Description shown in popup when no rules exist yet"
+  },
+  "popup_quick_rule": {
+    "message": "Quick Rule",
+    "description": "Quick rule button label in popup"
+  },
+  "popup_quick_rule_description": {
+    "message": "Add header rule in popup",
+    "description": "Quick rule button helper text in popup"
+  },
   "template_browser_title": {
     "message": "Browse Templates"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -490,6 +490,10 @@
   "quick_rule_placeholder_header_value": {
     "message": "e.g., custom-value"
   },
+  "quick_rule_common_headers": {
+    "message": "Common headers",
+    "description": "Label for header preset chips in quick rule form"
+  },
   "status_creating": {
     "message": "Creating..."
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -490,6 +490,10 @@
   "quick_rule_placeholder_header_value": {
     "message": "उदाहरण: custom-value"
   },
+  "quick_rule_common_headers": {
+    "message": "सामान्य हेडर",
+    "description": "Label for header preset chips in quick rule form"
+  },
   "status_creating": {
     "message": "बन रहा है..."
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -475,6 +475,10 @@
   "common_rule_name": {
     "message": "नियम का नाम"
   },
+  "common_optional": {
+    "message": "वैकल्पिक",
+    "description": "Suffix marking a form field as optional"
+  },
   "quick_rule_placeholder_name": {
     "message": "हेडर्स के लिए"
   },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -604,6 +604,22 @@
   "popup_footer_developers": {
     "message": "डेवलपर्स के लिए, डेवलपर्स द्वारा।"
   },
+  "popup_onboarding_title": {
+    "message": "अपना पहला हेडर सेट करें",
+    "description": "Title shown in popup when no rules exist yet"
+  },
+  "popup_onboarding_description": {
+    "message": "इस साइट के लिए कस्टम हेडर सेकंडों में जोड़ें — कोई खाता नहीं, असीमित नियम।",
+    "description": "Description shown in popup when no rules exist yet"
+  },
+  "popup_quick_rule": {
+    "message": "त्वरित नियम",
+    "description": "Quick rule button label in popup"
+  },
+  "popup_quick_rule_description": {
+    "message": "पॉपअप में हेडर नियम जोड़ें",
+    "description": "Quick rule button helper text in popup"
+  },
   "template_browser_title": {
     "message": "टेम्प्लेट ब्राउज़ करें"
   },

--- a/src/popup/components/PopupApp/PopupContent.tsx
+++ b/src/popup/components/PopupApp/PopupContent.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@/shared/components/Icon';
+import { useI18n } from '@/shared/hooks/useI18n';
 import type { HeaderRule } from '@/shared/types/rules';
 import type { ExtensionSettings } from '@/shared/types/storage';
 
@@ -55,6 +56,8 @@ export function PopupContent({
   onCloseTemplateBrowser,
   onProfileChange,
 }: Readonly<PopupContentProps>) {
+  const { t } = useI18n();
+
   // Filter rules based on active profile
   const filteredRules = state.rules.filter(rule => {
     if (state.activeProfile === 'unassigned') {
@@ -66,6 +69,10 @@ export function PopupContent({
     }
   });
 
+  const isFirstRun = state.rules.length === 0;
+  const showOnboarding =
+    isFirstRun && !showQuickCreator && !showTemplateBrowser;
+
   return (
     <div className={`${isCompact ? 'p-3 space-y-3' : 'p-4 space-y-4'}`}>
       <QuickToggle
@@ -74,23 +81,72 @@ export function PopupContent({
         compact={isCompact}
       />
 
-      {/* Profile Switcher */}
-      <ProfileSwitcher
-        className="w-full"
-        activeProfile={state.activeProfile}
-        onProfileChange={onProfileChange}
-      />
+      {/* Profile Switcher — only meaningful once rules exist */}
+      {!isFirstRun && (
+        <ProfileSwitcher
+          className="w-full"
+          activeProfile={state.activeProfile}
+          onProfileChange={onProfileChange}
+        />
+      )}
 
-      <RulesList
-        rules={filteredRules}
-        currentUrl={currentTab?.url}
-        onToggleRule={onToggleRule}
-        onEditRule={onEditRule}
-        onDeleteRule={onDeleteRule}
-        compact={isCompact}
-      />
+      {showOnboarding && (
+        <div className="text-center py-4 space-y-3">
+          <div className="mx-auto w-12 h-12 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
+            <Icon
+              name="zap"
+              className="w-6 h-6 text-primary-600 dark:text-primary-400"
+            />
+          </div>
+          <div>
+            <h2 className="font-semibold text-gray-900 dark:text-white">
+              {t('popup_onboarding_title')}
+            </h2>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {t('popup_onboarding_description')}
+            </p>
+          </div>
+          <button
+            onClick={
+              currentTab?.url
+                ? onCreateRuleForCurrentPage
+                : onOpenAdvancedRuleCreator
+            }
+            className="w-full btn btn-primary btn-sm"
+          >
+            <Icon name="plus" className="w-4 h-4 mr-2" />
+            {t('action_create_rule')}
+          </button>
+          <div className="flex items-center justify-center gap-3 text-xs">
+            <button
+              onClick={onShowTemplateBrowser}
+              className="text-primary-600 dark:text-primary-400 hover:underline"
+            >
+              {t('template_browser_title')}
+            </button>
+            <span className="text-gray-300 dark:text-gray-600">·</span>
+            <button
+              onClick={onOpenAdvancedRuleCreator}
+              className="text-primary-600 dark:text-primary-400 hover:underline"
+            >
+              {t('popup_create_advanced_rule')}
+            </button>
+          </div>
+        </div>
+      )}
 
-      {currentTab?.url && !showQuickCreator && (
+      {!isFirstRun && (
+        <RulesList
+          rules={filteredRules}
+          currentUrl={currentTab?.url}
+          onToggleRule={onToggleRule}
+          onEditRule={onEditRule}
+          onDeleteRule={onDeleteRule}
+          compact={isCompact}
+        />
+      )}
+
+      {!isFirstRun && currentTab?.url && !showQuickCreator && (
         <div className={`${isCompact ? 'space-y-1' : 'space-y-2'}`}>
           <button
             onClick={onCreateRuleForCurrentPage}
@@ -102,12 +158,12 @@ export function PopupContent({
                 className={`${isCompact ? 'w-4 h-4' : 'w-5 h-5'}`}
               />
               <span className={`font-medium ${isCompact ? 'text-sm' : ''}`}>
-                Quick Rule
+                {t('popup_quick_rule')}
               </span>
             </div>
             {!isCompact && (
               <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
-                Add header rule in popup
+                {t('popup_quick_rule_description')}
               </p>
             )}
           </button>
@@ -121,14 +177,14 @@ export function PopupContent({
                 name="file-text"
                 className={`${isCompact ? 'w-3 h-3' : 'w-4 h-4'} mr-2`}
               />
-              Browse Templates
+              {t('template_browser_title')}
             </button>
 
             <button
               onClick={onOpenAdvancedRuleCreator}
               className={`w-full btn btn-secondary ${isCompact ? 'btn-xs' : 'btn-sm'}`}
             >
-              Advanced Rule Creator
+              {t('popup_create_advanced_rule')}
             </button>
           </div>
         </div>

--- a/src/popup/components/QuickRuleCreator/QuickRuleForm.tsx
+++ b/src/popup/components/QuickRuleCreator/QuickRuleForm.tsx
@@ -45,7 +45,10 @@ export function QuickRuleForm({
           htmlFor="quick-rule-name"
           className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
         >
-          {t('common_rule_name')}
+          {t('common_rule_name')}{' '}
+          <span className="font-normal text-gray-400 dark:text-gray-500">
+            ({t('common_optional')})
+          </span>
         </label>
         <input
           type="text"
@@ -54,7 +57,6 @@ export function QuickRuleForm({
           onChange={e => setRuleName((e.target as HTMLInputElement).value)}
           placeholder={`${t('quick_rule_placeholder_name')} ${domain}`}
           className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-          required
         />
       </div>
 
@@ -122,12 +124,7 @@ export function QuickRuleForm({
       <div className="flex space-x-2 pt-2">
         <button
           type="submit"
-          disabled={
-            isSubmitting ||
-            !ruleName.trim() ||
-            !headerName.trim() ||
-            !headerValue.trim()
-          }
+          disabled={isSubmitting || !headerName.trim() || !headerValue.trim()}
           className="flex-1 btn btn-primary btn-sm"
         >
           {isSubmitting ? t('status_creating') : t('action_create_rule')}

--- a/src/popup/components/QuickRuleCreator/QuickRuleForm.tsx
+++ b/src/popup/components/QuickRuleCreator/QuickRuleForm.tsx
@@ -1,5 +1,16 @@
 import { useI18n } from '@/shared/hooks/useI18n';
 
+// Common developer headers offered as one-click presets. Values are
+// examples the user is expected to adjust; ${uuid()} showcases the
+// variable system.
+const HEADER_PRESETS: ReadonlyArray<{ name: string; value: string }> = [
+  { name: 'Authorization', value: 'Bearer ' },
+  { name: 'X-Api-Key', value: '' },
+  { name: 'X-Request-Id', value: '${uuid()}' },
+  { name: 'X-Forwarded-For', value: '127.0.0.1' },
+  { name: 'Cache-Control', value: 'no-cache' },
+];
+
 interface QuickRuleFormProps {
   ruleName: string;
   setRuleName: (name: string) => void;
@@ -45,6 +56,31 @@ export function QuickRuleForm({
           className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           required
         />
+      </div>
+
+      <div>
+        <span className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          {t('quick_rule_common_headers')}
+        </span>
+        <div className="flex flex-wrap gap-1">
+          {HEADER_PRESETS.map(preset => (
+            <button
+              key={preset.name}
+              type="button"
+              onClick={() => {
+                setHeaderName(preset.name);
+                setHeaderValue(preset.value);
+              }}
+              className={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+                headerName === preset.name
+                  ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                  : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-primary-400'
+              }`}
+            >
+              {preset.name}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div>

--- a/src/popup/components/QuickRuleCreator/hooks/useQuickRuleCreator.ts
+++ b/src/popup/components/QuickRuleCreator/hooks/useQuickRuleCreator.ts
@@ -43,7 +43,7 @@ export function useQuickRuleCreator(
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
 
-    if (!ruleName.trim() || !headerName.trim() || !headerValue.trim()) {
+    if (!headerName.trim() || !headerValue.trim()) {
       return;
     }
 
@@ -53,7 +53,7 @@ export function useQuickRuleCreator(
       const pattern = getPatternFromUrl(currentUrl);
       const newRule: HeaderRule = {
         id: `rule_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-        name: ruleName.trim(),
+        name: ruleName.trim() || `${headerName.trim()} @ ${pattern.domain}`,
         pattern,
         headers: [
           {


### PR DESCRIPTION
## Phase 2 of the adoption roadmap: the first 60 seconds

Most users decide within a minute of install whether an extension stays. The old empty popup offered four competing CTAs and a blank slate; creating the first rule required filling three form fields with no guidance.

### Commits (one per roadmap step)

1. **feat: focus popup empty state on a single primary action** — first-run users now see one clear path: a hero block with a single "Create Rule" button (pre-filled with the current tab's domain), with templates and the advanced editor demoted to small text links. The profile switcher is hidden until at least one rule exists (it's meaningless before then). Also localizes the previously hardcoded popup button strings ("Quick Rule", "Browse Templates", "Advanced Rule Creator") in both English and Hindi.
2. **feat: add common-header presets to quick rule creator** — one-click chips for `Authorization`, `X-Api-Key`, `X-Request-Id` (pre-filled with `${uuid()}`, showcasing the variable system), `X-Forwarded-For`, and `Cache-Control` that fill the header name/value fields.
3. **feat: make rule name optional with auto-generated fallback in quick rule creator** — the name auto-generates as `<header> @ <domain>` when left blank, cutting required fields from three to two. (The roadmap originally planned an active-rule-count toolbar badge here, but the codebase already ships one — the step was swapped for this friction cut.)
4. **docs: mark phase 2 complete in roadmap**

### Verification

- `npm run lint` ✅ (0 errors), `npm run type-check` ✅, `npx vitest run` ✅ 65 passed, `npm run validate-messages` ✅ (en/hi consistent, 347 keys each), `npm run build` ✅, Prettier ✅

https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ)_