### PR TITLE
feat: adoption roadmap phase 3 — modheader migration magnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ content, phone home, collect analytics, or require an account.
 | Dynamic variables/functions | ✅              | Paid                                  | Partial                 | ❌                    |
 | DevTools rule inspector     | ✅              | ❌                                    | Partial                 | ❌                    |
 
+Coming from ModHeader? RequestKit imports your exported profiles in one
+click — see [Switching from ModHeader](docs/switching-from-modheader.md).
+
 ## Quick start
 
 1. Click the RequestKit icon and choose **Quick Rule**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,7 +72,7 @@ it.
       Import/Export).
 - [x] Step 2: "Switching from ModHeader" guide documenting the import path
       and feature mapping. (`docs`)
-- [ ] Step 3: Update roadmap progress. (`docs`)
+- [x] Step 3: Update roadmap progress. (`docs`)
 
 ## Phase 4 — Focus (declutter the options surface)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Current empty state offers four competing CTAs and a blank slate.
 The incumbent's 800k users are protected mainly by switching cost. Remove
 it.
 
-- [ ] Step 1: One-click ModHeader JSON import (auto-detected in
+- [x] Step 1: One-click ModHeader JSON import (auto-detected in
       Import/Export).
 - [ ] Step 2: "Switching from ModHeader" guide documenting the import path
       and feature mapping. (`docs`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ it.
 
 - [x] Step 1: One-click ModHeader JSON import (auto-detected in
       Import/Export).
-- [ ] Step 2: "Switching from ModHeader" guide documenting the import path
+- [x] Step 2: "Switching from ModHeader" guide documenting the import path
       and feature mapping. (`docs`)
 - [ ] Step 3: Update roadmap progress. (`docs`)
 

--- a/docs/switching-from-modheader.md
+++ b/docs/switching-from-modheader.md
@@ -1,0 +1,52 @@
+# Switching from ModHeader
+
+RequestKit imports ModHeader profiles in one click — no account, no rule
+caps, no ads, and everything ModHeader paywalled (unlimited rules,
+profiles, dynamic values) is free.
+
+## Import your ModHeader setup
+
+1. In ModHeader, open the profile menu and choose **Export profile** to
+   download your profiles as a JSON file.
+2. In RequestKit, open **Options → Import/Export**.
+3. Choose the exported file under **Import Data**. RequestKit detects the
+   ModHeader format automatically and converts each profile into header
+   rules.
+4. Pick **merge** to keep your existing RequestKit rules, or **replace**
+   to start fresh.
+
+### What the importer converts
+
+| ModHeader                  | RequestKit                                                      |
+| -------------------------- | --------------------------------------------------------------- |
+| Profile                    | One rule per profile (or one per URL filter)                    |
+| Request headers            | Request headers (`set` operation)                               |
+| Response headers           | Response headers                                                |
+| Append mode                | `append` operation on each header                               |
+| URL filters (simple regex) | Wildcard domain patterns (`.*\.example\.com` → `*.example.com`) |
+| Disabled header entries    | Skipped                                                         |
+
+Complex URL regexes that can't be translated into wildcard patterns fall
+back to matching all sites; the original regex is preserved in the rule's
+description so you can recreate it as a precise pattern. Imported rules
+are tagged `modheader-import` for easy review.
+
+## Feature mapping
+
+| You used in ModHeader        | In RequestKit                                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Profiles + profile switcher  | Profiles tab; switch from the popup                                                                                  |
+| Dynamic values (Pro)         | Variables: `${uuid()}`, `${timestamp()}`, `${random()}`, `${base64()}`, `${date()}` and custom `${variables}` — free |
+| Tab/URL filtering            | Wildcard URL patterns: protocol, domain, path, query, port                                                           |
+| Export/backup (cloud)        | Plain JSON export — version-control it, share it, no cloud account                                                   |
+| Checking headers in DevTools | RequestKit panel in DevTools shows matched rules and resolved variables                                              |
+
+## What's different
+
+- **No rule limits.** ModHeader's free tier caps you at 10 rules;
+  RequestKit has no caps of any kind.
+- **No account or sign-in.** Everything is stored in your browser.
+- **No ads or sponsored tabs.** RequestKit makes zero network requests of
+  its own — verify it in the source.
+- **No content scripts.** RequestKit modifies headers through Chrome's
+  native `declarativeNetRequest` engine and runs no code in your pages.

--- a/src/__tests__/modheader-import.test.ts
+++ b/src/__tests__/modheader-import.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  convertModHeaderExport,
+  isModHeaderExport,
+} from '@/lib/integrations/modheader-importer';
+
+const modHeaderProfile = {
+  title: 'Staging auth',
+  headers: [
+    { enabled: true, name: 'Authorization', value: 'Bearer abc123' },
+    { enabled: false, name: 'X-Disabled', value: 'skip-me' },
+    { enabled: true, name: '', value: 'nameless' },
+  ],
+  respHeaders: [{ enabled: true, name: 'X-Debug', value: '1' }],
+  urlFilters: [{ enabled: true, urlRegex: '.*\\.example\\.com' }],
+  appendMode: false,
+};
+
+describe('isModHeaderExport', () => {
+  it('detects an array of ModHeader profiles', () => {
+    expect(isModHeaderExport([modHeaderProfile])).toBe(true);
+  });
+
+  it('detects a single ModHeader profile object', () => {
+    expect(isModHeaderExport(modHeaderProfile)).toBe(true);
+  });
+
+  it('rejects RequestKit exports', () => {
+    expect(
+      isModHeaderExport({
+        version: '1.0.0',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        rules: [],
+      })
+    ).toBe(false);
+  });
+
+  it('rejects empty arrays, primitives, and unrelated objects', () => {
+    expect(isModHeaderExport([])).toBe(false);
+    expect(isModHeaderExport('headers')).toBe(false);
+    expect(isModHeaderExport(null)).toBe(false);
+    expect(isModHeaderExport({ foo: 'bar' })).toBe(false);
+  });
+});
+
+describe('convertModHeaderExport', () => {
+  it('converts a profile into a rule with request and response headers', () => {
+    const rules = convertModHeaderExport([modHeaderProfile]);
+
+    expect(rules).toHaveLength(1);
+    const rule = rules[0];
+    expect(rule?.name).toBe('Staging auth');
+    expect(rule?.enabled).toBe(true);
+    expect(rule?.tags).toContain('modheader-import');
+    expect(rule?.headers).toEqual([
+      {
+        name: 'Authorization',
+        value: 'Bearer abc123',
+        operation: 'set',
+        target: 'request',
+      },
+      { name: 'X-Debug', value: '1', operation: 'set', target: 'response' },
+    ]);
+  });
+
+  it('translates a subdomain wildcard url regex into a domain pattern', () => {
+    const rules = convertModHeaderExport([modHeaderProfile]);
+    expect(rules[0]?.pattern.domain).toBe('*.example.com');
+  });
+
+  it('falls back to all domains when no filters exist', () => {
+    const withoutFilters = { ...modHeaderProfile, urlFilters: [] };
+    const rules = convertModHeaderExport([withoutFilters]);
+    expect(rules[0]?.pattern.domain).toBe('*');
+  });
+
+  it('falls back to all domains and notes untranslatable regex filters', () => {
+    const rules = convertModHeaderExport([
+      {
+        ...modHeaderProfile,
+        urlFilters: [{ enabled: true, urlRegex: '(staging|prod)\\.api' }],
+      },
+    ]);
+    expect(rules[0]?.pattern.domain).toBe('*');
+    expect(rules[0]?.description).toContain('(staging|prod)\\.api');
+  });
+
+  it('creates one rule per translatable url filter', () => {
+    const rules = convertModHeaderExport([
+      {
+        ...modHeaderProfile,
+        urlFilters: [
+          { enabled: true, urlRegex: 'api\\.example\\.com' },
+          { enabled: true, urlRegex: 'staging\\.example\\.com' },
+        ],
+      },
+    ]);
+    expect(rules).toHaveLength(2);
+    expect(rules.map(r => r.pattern.domain)).toEqual([
+      'api.example.com',
+      'staging.example.com',
+    ]);
+    expect(rules[0]?.name).toBe('Staging auth (api.example.com)');
+  });
+
+  it('uses append operation when appendMode is on', () => {
+    const rules = convertModHeaderExport([
+      { ...modHeaderProfile, appendMode: true },
+    ]);
+    expect(rules[0]?.headers[0]?.operation).toBe('append');
+  });
+
+  it('skips profiles with no usable headers', () => {
+    const rules = convertModHeaderExport([
+      { title: 'Empty', headers: [{ enabled: false, name: 'X', value: '1' }] },
+    ]);
+    expect(rules).toHaveLength(0);
+  });
+
+  it('names untitled profiles by position', () => {
+    const rules = convertModHeaderExport([
+      { headers: [{ enabled: true, name: 'X-A', value: '1' }] },
+    ]);
+    expect(rules[0]?.name).toBe('ModHeader profile 1');
+  });
+});

--- a/src/lib/integrations/modheader-importer.ts
+++ b/src/lib/integrations/modheader-importer.ts
@@ -1,0 +1,163 @@
+/**
+ * One-click import of ModHeader profile exports.
+ *
+ * ModHeader exports a JSON array of profile objects (a single object for
+ * older versions). Each profile carries request headers, response headers,
+ * and optional URL regex filters. This module detects that shape and
+ * converts it into RequestKit header rules so switchers keep their setup.
+ */
+
+import type { HeaderEntry, HeaderRule } from '@/shared/types/rules';
+
+interface ModHeaderHeader {
+  enabled?: boolean;
+  name?: string;
+  value?: string;
+  comment?: string;
+}
+
+interface ModHeaderFilter {
+  enabled?: boolean;
+  type?: string;
+  urlRegex?: string;
+}
+
+interface ModHeaderProfile {
+  title?: string;
+  shortTitle?: string;
+  headers?: ModHeaderHeader[];
+  respHeaders?: ModHeaderHeader[];
+  urlFilters?: ModHeaderFilter[];
+  filters?: ModHeaderFilter[];
+  appendMode?: boolean | string;
+}
+
+function isModHeaderProfile(value: unknown): value is ModHeaderProfile {
+  if (typeof value !== 'object' || value === null) return false;
+  const profile = value as Record<string, unknown>;
+  // A profile must carry at least one header list; `title` alone is too
+  // weak a signal and `version`/`timestamp` mark RequestKit's own format.
+  if ('version' in profile && 'timestamp' in profile) return false;
+  return Array.isArray(profile.headers) || Array.isArray(profile.respHeaders);
+}
+
+/**
+ * Returns true when the parsed JSON looks like a ModHeader export
+ * (an array of profiles or a single profile object).
+ */
+export function isModHeaderExport(data: unknown): boolean {
+  if (Array.isArray(data)) {
+    return data.length > 0 && data.every(isModHeaderProfile);
+  }
+  return isModHeaderProfile(data);
+}
+
+/**
+ * Best-effort extraction of a RequestKit domain pattern from a ModHeader
+ * URL regex. Returns null when the regex is too complex to translate, in
+ * which case the caller falls back to matching all domains.
+ */
+function domainFromUrlRegex(urlRegex: string): string | null {
+  let pattern = urlRegex.trim();
+  if (!pattern) return null;
+
+  // Strip common anchors and protocol prefixes.
+  pattern = pattern.replace(/^\^/, '').replace(/\$$/, '');
+  pattern = pattern.replace(/^https?(\\?:)?(\/\/|\\\/\\\/)?/i, '');
+  // Unescape literal dots, the one regex escape ModHeader users actually use.
+  pattern = pattern.replace(/\\\./g, '.');
+  // Leading ".*" means "any subdomain" — RequestKit spells that "*."
+  pattern = pattern.replace(/^\.\*\.?/, '*.');
+  // Drop any path part; RequestKit patterns separate domain and path.
+  const domain = pattern.split('/')[0] ?? '';
+
+  // Give up if regex metacharacters remain beyond our wildcard.
+  if (/[\\^$+?()[\]{}|]/.test(domain) || domain === '' || domain === '*.') {
+    return null;
+  }
+  return domain;
+}
+
+function convertHeaders(
+  headers: ModHeaderHeader[] | undefined,
+  target: HeaderEntry['target'],
+  operation: HeaderEntry['operation']
+): HeaderEntry[] {
+  return (headers ?? [])
+    .filter(h => h.enabled !== false && h.name && h.name.trim() !== '')
+    .map(h => ({
+      name: (h.name as string).trim(),
+      value: h.value ?? '',
+      operation,
+      target,
+    }));
+}
+
+/**
+ * Converts a ModHeader export (array of profiles or single profile) into
+ * RequestKit header rules — one rule per profile. Profiles without any
+ * usable headers are skipped.
+ */
+export function convertModHeaderExport(data: unknown): HeaderRule[] {
+  const profiles: ModHeaderProfile[] = Array.isArray(data)
+    ? data.filter(isModHeaderProfile)
+    : isModHeaderProfile(data)
+      ? [data]
+      : [];
+
+  const now = new Date();
+  const rules: HeaderRule[] = [];
+
+  profiles.forEach((profile, index) => {
+    const operation: HeaderEntry['operation'] =
+      profile.appendMode === true || profile.appendMode === 'append'
+        ? 'append'
+        : 'set';
+
+    const headers = [
+      ...convertHeaders(profile.headers, 'request', operation),
+      ...convertHeaders(profile.respHeaders, 'response', operation),
+    ];
+    if (headers.length === 0) return;
+
+    const filters = [
+      ...(profile.urlFilters ?? []),
+      ...(profile.filters ?? []),
+    ].filter(f => f.enabled !== false && typeof f.urlRegex === 'string');
+
+    const domains = filters
+      .map(f => domainFromUrlRegex(f.urlRegex as string))
+      .filter((d): d is string => d !== null);
+
+    const untranslated = filters.length > 0 && domains.length < filters.length;
+    const description = untranslated
+      ? `Imported from ModHeader. Some URL filters could not be translated automatically — original filters: ${filters
+          .map(f => f.urlRegex)
+          .join(', ')}`
+      : 'Imported from ModHeader.';
+
+    const baseName = profile.title?.trim() || `ModHeader profile ${index + 1}`;
+    const ruleDomains = domains.length > 0 ? domains : ['*'];
+
+    ruleDomains.forEach((domain, domainIndex) => {
+      rules.push({
+        id: `rule_modheader_${Date.now()}_${index}_${domainIndex}`,
+        name: ruleDomains.length > 1 ? `${baseName} (${domain})` : baseName,
+        enabled: true,
+        pattern: {
+          protocol: '*',
+          domain,
+          path: '/*',
+        },
+        headers,
+        priority: 1,
+        createdAt: now,
+        updatedAt: now,
+        description,
+        tags: ['modheader-import'],
+      });
+    });
+  });
+
+  return rules;
+}

--- a/src/options/components/EnhancedImportExport/ImportSection.tsx
+++ b/src/options/components/EnhancedImportExport/ImportSection.tsx
@@ -18,7 +18,8 @@ export function ImportSection({ onImport }: ImportSectionProps) {
             className="w-12 h-12 mx-auto text-gray-400 mb-4"
           />
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            Select a RequestKit export file to import
+            Select a RequestKit export file to import — ModHeader profile
+            exports are detected and converted automatically
           </p>
           <label className="btn btn-primary">
             Choose File

--- a/src/options/components/EnhancedImportExport/hooks/useImportExportOperations.ts
+++ b/src/options/components/EnhancedImportExport/hooks/useImportExportOperations.ts
@@ -1,4 +1,8 @@
 import { STORAGE_KEYS } from '@/config/constants';
+import {
+  convertModHeaderExport,
+  isModHeaderExport,
+} from '@/lib/integrations/modheader-importer';
 import type { HeaderRule } from '@/shared/types/rules';
 import type { ExtensionSettings } from '@/shared/types/storage';
 import { ChromeApiUtils } from '@/shared/utils';
@@ -207,11 +211,23 @@ export function useImportExportOperations(
       setImportProgress({ show: true, step: 'Reading file...', progress: 10 });
 
       const text = await file.text();
-      const importData = JSON.parse(text) as ExportData;
+      const parsed = JSON.parse(text) as unknown;
 
-      // Validate import data
-      if (!importData.version || !importData.timestamp) {
-        throw new Error('Invalid export file format');
+      // ModHeader exports are auto-detected and converted so switchers
+      // can bring their profiles over in one click.
+      let importData: ExportData;
+      if (isModHeaderExport(parsed)) {
+        importData = {
+          version: 'modheader-import',
+          timestamp: new Date().toISOString(),
+          rules: convertModHeaderExport(parsed),
+        };
+      } else {
+        importData = parsed as ExportData;
+        // Validate import data
+        if (!importData.version || !importData.timestamp) {
+          throw new Error('Invalid export file format');
+        }
       }
 
       setImportProgress({


### PR DESCRIPTION
## Phase 3 of the adoption roadmap: remove the switching cost

ModHeader's ~800k users are protected mainly by the effort of recreating their setup. This PR removes that moat.

### Commits (one per roadmap step)

1. **feat: auto-detect and convert modheader exports on import** — new `src/lib/integrations/modheader-importer.ts`, a pure converter that detects ModHeader's export shape (array of profiles or single profile) and maps it to RequestKit rules:
   - request `headers` and `respHeaders` → request/response header entries (`set`, or `append` when the profile used append mode)
   - simple URL regex filters → wildcard domain patterns (`.*\.example\.com` → `*.example.com`), one rule per translatable filter; untranslatable regexes fall back to all-domains with the original regex preserved in the rule description
   - disabled header entries are skipped; imported rules are tagged `modheader-import`
   - wired into the existing Import/Export flow (`useImportExportOperations.ts`) with format auto-detection — RequestKit's own format is detected by its `version`+`timestamp` envelope and handled as before
   - 12 new unit tests (`src/__tests__/modheader-import.test.ts`)
2. **docs: add switching-from-modheader migration guide** — `docs/switching-from-modheader.md` with step-by-step import instructions, a conversion table, and a ModHeader→RequestKit feature mapping; linked from the README comparison section.
3. **docs: mark phase 3 complete in roadmap**

### Verification

- `npm run lint` ✅ (0 errors), `npm run type-check` ✅, `npx vitest run` ✅ 77 passed (12 new), `npm run format:check` ✅

https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ)_