### PR TITLE
feat: adoption roadmap phase 5 — reliability visible & launch kit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,13 +91,23 @@ Keep the power, reduce the apparent complexity.
       trust fix.)
 - [x] Step 3: Update roadmap progress. (`docs`)
 
+## Phase 5 — Reliability visible & launch kit
+
+The category's reputation is "silently broken" — users no longer trust
+that headers are actually set. Make correctness visible, and prepare the
+store listing that converts.
+
+- [x] Step 1: Fix the per-tab badge to use the real pattern matcher — it
+      used naive substring matching, so wildcard rules (e.g.
+      `*.example.com`) never counted and the badge under-reported what was
+      actually applied. Adds regression tests. (`fix`)
+- [ ] Step 2: Chrome Web Store listing kit — title, summary, description
+      leading with the trust contract, screenshot plan, and category/
+      keyword guidance. (`docs`)
+- [ ] Step 3: Update roadmap progress. (`docs`)
+
 ## Backlog (future phases)
 
-- Per-tab "rules applied" indicator — make reliability visible (the
-  category's reputation is "silently broken"); market the DevTools panel
-  as "see your headers actually working".
-- Store listing kit: screenshots, copy leading with the trust contract,
-  privacy policy link, "why these permissions" section.
 - "ModHeader alternative" / "Header Editor replacement" landing pages for
   switcher SEO traffic.
 - Optional narrow-permission install mode (site-specific host permissions).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,7 +101,7 @@ store listing that converts.
       used naive substring matching, so wildcard rules (e.g.
       `*.example.com`) never counted and the badge under-reported what was
       actually applied. Adds regression tests. (`fix`)
-- [ ] Step 2: Chrome Web Store listing kit — title, summary, description
+- [x] Step 2: Chrome Web Store listing kit — title, summary, description
       leading with the trust contract, screenshot plan, and category/
       keyword guidance. (`docs`)
 - [ ] Step 3: Update roadmap progress. (`docs`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,7 +104,7 @@ store listing that converts.
 - [x] Step 2: Chrome Web Store listing kit — title, summary, description
       leading with the trust contract, screenshot plan, and category/
       keyword guidance. (`docs`)
-- [ ] Step 3: Update roadmap progress. (`docs`)
+- [x] Step 3: Update roadmap progress. (`docs`)
 
 ## Backlog (future phases)
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,0 +1,101 @@
+# Chrome Web Store Listing Kit
+
+Copy-paste material for the Chrome Web Store listing. Listing quality is a
+ranking factor and the primary conversion surface; this kit leads with the
+trust contract because that is the category's open wound.
+
+## Title (max 45 characters)
+
+> RequestKit — Modify HTTP Headers
+
+Alternative if search ranking for "modheader" matters more than brand:
+
+> RequestKit: Free Header Editor
+
+## Summary (max 132 characters)
+
+> Inject, override, or remove request headers with wildcard patterns and
+> profiles. Free forever — no account, no ads, no telemetry.
+
+## Description
+
+```
+Modify HTTP request and response headers the way it should work: free,
+private, and reliable on Manifest V3.
+
+THE TRUST CONTRACT
+• Free forever — unlimited rules, unlimited profiles, no Pro tier
+• No account, no sign-in, no cloud — your rules stay in your browser
+• No ads, no sponsored tabs, no telemetry — zero network calls of its own
+• Open source — audit every line: github.com/navbytes/RequestKit
+
+ZERO PAGE OVERHEAD
+RequestKit modifies headers through Chrome's native declarativeNetRequest
+engine. It injects no content scripts and runs no code in your pages, so
+it adds nothing to page load time. Built MV3-native from day one — not a
+ported legacy extension that breaks when Chrome tightens the rules.
+
+FOR DEVELOPERS
+• Wildcard URL patterns: protocol, domain, path, query, port
+  (*.staging.example.com/api/*)
+• Profiles: group rules by environment (dev / staging / prod) and switch
+  from the toolbar
+• Dynamic variables: ${uuid()}, ${timestamp()}, ${base64()}, custom
+  ${variables} with rule > profile > global scoping
+• One-click presets for Authorization, X-Api-Key, X-Request-Id and more
+• DevTools panel: see which rules matched and how variables resolved —
+  proof your headers are actually applied
+• Toolbar badge shows how many rules apply to the current tab
+• Plain-JSON import/export — version-control your setup
+
+SWITCHING FROM MODHEADER?
+Import your exported ModHeader profiles in one click — RequestKit detects
+the format automatically and converts profiles, headers, and URL filters.
+
+WHY THE BROAD PERMISSION?
+Any extension that modifies headers needs host access for the sites you
+target. Your rules decide what is matched; everything else is untouched.
+RequestKit never reads page content, never phones home, and collects
+nothing. Privacy policy:
+github.com/navbytes/RequestKit/blob/main/PRIVACY_POLICY.md
+```
+
+## Category & language
+
+- Category: **Developer Tools**
+- Language: English (Hindi localization ships in-package via `_locales`)
+
+## Screenshots (1280×800, take in light theme, fresh profile)
+
+1. **Popup with rules active** — 2–3 rules listed, badge visible on the
+   toolbar icon, one rule marked as matching the current tab. Caption:
+   "See exactly which rules apply to this tab."
+2. **First-run popup** — the single-CTA empty state. Caption: "Your first
+   header in under 30 seconds."
+3. **Quick rule with presets** — preset chips visible, `${uuid()}` in the
+   value field. Caption: "One-click presets and dynamic variables."
+4. **DevTools panel** — request list with matched rules. Caption: "Proof
+   your headers are actually applied."
+5. **Options → Import** — ModHeader file being imported. Caption:
+   "Switching from ModHeader takes one click."
+
+## Promo copy variants (for launch posts)
+
+- Show HN: "RequestKit – open-source ModHeader alternative with no
+  account, no ads, no rule caps"
+- r/webdev: lead with the MV2 shutdown stranding Header Editor users and
+  ModHeader's monetization turn; position RequestKit as the boring,
+  trustworthy option.
+
+## Listing hygiene checklist
+
+- [ ] Privacy policy URL set (PRIVACY_POLICY.md or a hosted page)
+- [ ] All five screenshots uploaded with captions
+- [ ] "Single purpose" description: "Modify HTTP request/response headers
+      on user-defined URL patterns"
+- [ ] Permission justifications filled in (copy from the "why the broad
+      permission" section above)
+- [ ] Support email + GitHub issues link set
+- [ ] Ask early GitHub users for honest store reviews after launch —
+      listings with ~10 genuine reviews rank measurably better than
+      zero-review listings

--- a/src/__tests__/badge-manager.test.ts
+++ b/src/__tests__/badge-manager.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BadgeManager } from '@/background/services/badge-manager';
+import type { HeaderRule } from '@/shared/types/rules';
+
+function makeRule(overrides: Partial<HeaderRule> = {}): HeaderRule {
+  return {
+    id: 'rule_1',
+    name: 'Test rule',
+    enabled: true,
+    pattern: { protocol: '*', domain: '*.example.com', path: '/*' },
+    headers: [
+      { name: 'X-Test', value: '1', operation: 'set', target: 'request' },
+    ],
+    priority: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('BadgeManager.updateBadgeForTab', () => {
+  beforeEach(() => {
+    vi.mocked(chrome.action.setBadgeText).mockClear();
+  });
+
+  it('counts rules with wildcard domains that match the tab url', async () => {
+    await BadgeManager.updateBadgeForTab(
+      1,
+      'https://api.example.com/v1/users',
+      true,
+      { rule_1: makeRule() }
+    );
+
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({
+      text: '1',
+      tabId: 1,
+    });
+  });
+
+  it('clears the badge when no rule matches the tab url', async () => {
+    await BadgeManager.updateBadgeForTab(1, 'https://other-site.org/', true, {
+      rule_1: makeRule(),
+    });
+
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({
+      text: '',
+      tabId: 1,
+    });
+  });
+
+  it('ignores disabled rules', async () => {
+    await BadgeManager.updateBadgeForTab(
+      1,
+      'https://api.example.com/v1/users',
+      true,
+      { rule_1: makeRule({ enabled: false }) }
+    );
+
+    expect(chrome.action.setBadgeText).toHaveBeenCalledWith({
+      text: '',
+      tabId: 1,
+    });
+  });
+
+  it('does nothing while the extension is disabled', async () => {
+    await BadgeManager.updateBadgeForTab(
+      1,
+      'https://api.example.com/v1/users',
+      false,
+      { rule_1: makeRule() }
+    );
+
+    expect(chrome.action.setBadgeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/background/services/badge-manager.ts
+++ b/src/background/services/badge-manager.ts
@@ -2,6 +2,7 @@
  * Extension badge management service
  */
 
+import { matchURLPattern } from '@/lib/core/pattern-matcher';
 import type { HeaderRule } from '@/shared/types/rules';
 import { ChromeApiUtils } from '@/shared/utils/chrome-api';
 import { loggers } from '@/shared/utils/debug';
@@ -50,11 +51,16 @@ export class BadgeManager {
     try {
       if (!isEnabled) return;
 
-      // Count matching rules for this URL
+      // Count matching rules for this URL using the same pattern matcher
+      // the rule engine uses, so the badge reflects what actually applies
+      // (naive substring matching never matched wildcard domains).
       const matchingRules = Object.values(rules).filter(rule => {
         if (!rule.enabled) return false;
-        // Simple URL matching - in a real implementation, use the pattern matcher
-        return url.includes(rule.pattern.domain);
+        try {
+          return matchURLPattern(url, rule.pattern).matches;
+        } catch {
+          return false;
+        }
       });
 
       if (matchingRules.length > 0) {


### PR DESCRIPTION
## Phase 5 of the adoption roadmap: make correctness visible, prepare to launch

The category's reputation is "silently broken" — users no longer trust that headers are actually set. This phase fixes the one place RequestKit itself was silently wrong, and ships the store-listing material for launch.

### Commits (one per roadmap step)

1. **fix: use pattern matcher for per-tab badge rule counting** — `BadgeManager.updateBadgeForTab` used naive `url.includes(rule.pattern.domain)` matching, so wildcard rules (e.g. `*.example.com`) never counted and the per-tab badge under-reported what was actually applied — exactly the "is this even working?" failure mode that kills trust in this category. It now uses the same `matchURLPattern` engine as the rule processor and popup. Includes 4 regression tests (`src/__tests__/badge-manager.test.ts`).
2. **docs: add chrome web store listing kit** — `docs/store-listing.md` with ready-to-paste title, summary, and description leading with the trust contract; a 5-screenshot plan with captions; permission justifications; launch-post variants; and a listing hygiene checklist.
3. **docs: mark phase 5 complete in roadmap** — Phase 5 was promoted from the backlog; remaining backlog (SEO landing pages, narrow-permission mode, Requestly importer, Firefox/Edge ports, launch) stays recorded in `ROADMAP.md`.

### Verification

- `npm run lint` ✅ (0 errors), `npm run type-check` ✅, `npx vitest run` ✅ 81 passed (4 new), Prettier ✅

https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ)_