### PR TITLE
build: update preact to 10.29 and fix stricter type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "date-fns": "^4.4.0",
         "debug": "^4.4.3",
         "lucide-preact": "^0.525.0",
-        "preact": "10.19.3",
+        "preact": "^10.29.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -5952,7 +5952,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.19.3",
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "date-fns": "^4.4.0",
     "debug": "^4.4.3",
     "lucide-preact": "^0.525.0",
-    "preact": "10.19.3",
+    "preact": "^10.29.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/options/components/EnhancedImportExport/ExportSection.tsx
+++ b/src/options/components/EnhancedImportExport/ExportSection.tsx
@@ -1,4 +1,4 @@
-import { StateUpdater } from 'preact/hooks';
+import { Dispatch, StateUpdater } from 'preact/hooks';
 
 import { ExportButtons } from './ExportSection/ExportButtons';
 import {
@@ -23,7 +23,7 @@ interface ExportData {
 
 interface ExportSectionProps {
   exportOptions: ExportOptionsState;
-  setExportOptions: StateUpdater<ExportOptionsState>;
+  setExportOptions: Dispatch<StateUpdater<ExportOptionsState>>;
   onExport: () => void;
   onQuickExport: (type: 'rules' | 'templates' | 'profiles') => void;
   rulesCount: number;

--- a/src/shared/components/VariableForm.tsx
+++ b/src/shared/components/VariableForm.tsx
@@ -436,7 +436,6 @@ export function VariableForm({
                   }))
                 }
                 placeholder="Enter value with optional functions like ${uuid()}, ${timestamp()}, etc."
-                type={formData.isSecret ? 'password' : 'text'}
                 required
               />
               {formData.isSecret && (

--- a/src/shared/components/VariableInput.tsx
+++ b/src/shared/components/VariableInput.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 
 import { VariableResolver } from '@/lib/core';
@@ -238,7 +239,10 @@ export function VariableInput({
     <div className="relative">
       <div className="relative">
         <InputComponent
-          ref={inputRef as React.Ref<HTMLInputElement & HTMLTextAreaElement>}
+          ref={
+            inputRef as RefObject<HTMLInputElement> &
+              RefObject<HTMLTextAreaElement>
+          }
           type={multiline ? undefined : 'text'}
           value={value}
           onInput={handleInputChange}


### PR DESCRIPTION
Supersedes Dependabot's #17, which failed CI because preact 10.29 ships stricter TypeScript types. This PR applies the same bump plus the four resulting app-side type fixes:

- `ExportSection.tsx` / `index.tsx`: the `useState` setter is now `Dispatch<StateUpdater<S>>` in preact's types — the prop type updated to match (no runtime change).
- `VariableForm.tsx`: removed a `type` attribute that was set on a `<textarea>` (textareas have no `type`; it was a no-op in the DOM and is now a type error).
- `VariableInput.tsx`: the shared input/textarea ref now uses an explicit `RefObject<HTMLInputElement> & RefObject<HTMLTextAreaElement>` cast, which is what the dynamic-element union requires.

Verification: lint 0 errors, type-check clean, 81 tests pass, production build succeeds.

https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LzDMTNVr1gKVzJrunv3BZ)_